### PR TITLE
Memory leaks

### DIFF
--- a/src/Compiler.cpp
+++ b/src/Compiler.cpp
@@ -100,6 +100,7 @@ Compiler::~Compiler(){
         for(auto& stmt : frame){
             if(stmt != nullptr){
                 delete stmt;
+                stmt = nullptr;
             }
         }
         flattenStmt.pop();

--- a/src/Compiler.cpp
+++ b/src/Compiler.cpp
@@ -113,9 +113,15 @@ Object* Compiler::flatten(Object* expr){
     Int32 Type = expr->getType();
     LOG("    Type: "+STR(Type));
     /* Primatives */
+    /*
+     We cannot just return the primative expr/node, as the original
+     AST holds a reference to these nodes. Otherwise, freeing
+     the memory of the original AST and the flatAST will cause
+     a double free assert.
+     */
     if(Type == VAR || Type == INTEGER || Type == FLOAT ||
        Type == DOUBLE || Type == STRING || Type == BOOLEAN){
-        return expr;
+        return expr->clone();
     }
     /* Unary */
     else if(Type == UNARY){

--- a/src/Compiler.cpp
+++ b/src/Compiler.cpp
@@ -105,6 +105,13 @@ Compiler::~Compiler(){
         }
         flattenStmt.pop();
     }
+    
+    for(auto& tree : ast){
+        if(tree != nullptr){
+            delete tree;
+            tree = nullptr;
+        }
+    }
 }
 
 Object* Compiler::flatten(Object* expr){
@@ -199,7 +206,7 @@ Object* Compiler::flatten(Object* expr){
         pushNewFlatStack();
         vector<Object*> body_stmt = s->getStatements();
         for(const auto& stmt : body_stmt){
-            flatten(stmt);
+            flatten(stmt->clone());
         }
         vector<Object*> flatBody  = popFlatStack();
         return new Seq(flatBody);

--- a/src/Compiler.cpp
+++ b/src/Compiler.cpp
@@ -574,7 +574,8 @@ Tuple(string, Int32) Compiler::compile(Object* expr){
         Int32 ltype = getType(c->getLeft());
         Int32 rtype = getType(c->getRight());
         if(ltype != rtype){
-            RaisePineException("Comparison operation require like-type operands.");
+            RaisePineException("Comparison operation require like-type operands.\n"
+                               "Recieved ("+getTypeName(ltype)+") and ("+getTypeName(rtype)+")");
         }
         string instruction;
         /* Jump if comparison is false */

--- a/src/Compiler.hpp
+++ b/src/Compiler.hpp
@@ -8,6 +8,7 @@
 class Compiler {
 private:
     vector<Object*> ast;
+    vector<Object*> flatAst;
     
     stack<vector<Object*>> flattenStmt;
     stack<vector<string>> compileStmt;

--- a/src/Foundation.cpp
+++ b/src/Foundation.cpp
@@ -1,6 +1,7 @@
 #include "Foundation.hpp"
 
 vector<string> Trace;
+map<Int32, Object*> memoryPool;
 
 void DEBUG(string message){
     LOG("Foundation:DEBUG");
@@ -40,10 +41,22 @@ bool isPrimative(Int32 Type){
             Type == BOOLEAN);
 }
 
-Object::Object(){LOG("Foundation:Object");}
+Object::Object(){
+    static UInt32 memoryPoolID = 0;
+    LOG("Foundation:Object");
+    LOG("    memoryPoolID: "+STR(memoryPoolID));
+    
+    poolID = memoryPoolID;
+    memoryPool[memoryPoolID] = this;
+    
+    memoryPoolID += 1;
+}
 Object::~Object(){LOG("Foundation:~Object");}
 Int32 Object::getType(){
     return Type;
+}
+UInt32 Object::getMemoryPoolID(){
+    return poolID;
 }
 void Object::print(){
     cout<<"Obj()"<<endl;
@@ -185,7 +198,7 @@ Let::Let(string _lval, Int32 _expectedType, Object* _rval){
 
 Let::~Let(){
     if(rval != nullptr){
-        delete rval;
+        deleteObject(rval);
         rval = nullptr;
     }
 }
@@ -227,11 +240,11 @@ Binary::Binary(Int32 _operation, Object* l, Object* r){
 Binary::~Binary(){
     LOG("Foundation:~Binary");
     if(left != nullptr){
-        delete left;
+        deleteObject(left);
         left = nullptr;
     }
     if(right != nullptr){
-        delete right;
+        deleteObject(right);
         right = nullptr;
     }
 }
@@ -306,11 +319,11 @@ Compare::Compare(Int32 _operation, Object* l, Object* r){
 
 Compare::~Compare(){
     if(left != nullptr){
-        delete left;
+        deleteObject(left);
         left = nullptr;
     }
     if(right != nullptr){
-        delete right;
+        deleteObject(right);
         right = nullptr;
     }
 }
@@ -415,7 +428,7 @@ Print::Print(Object* _val){
 Print::~Print(){
     LOG("Foundation:~Print");
     if(val != nullptr){
-        delete val;
+        deleteObject(val);
         val = nullptr;
     }
 }
@@ -444,12 +457,12 @@ Function::~Function(){
     LOG("Foundation:~Function");
     for(const auto &elem : argv){
         if(elem != nullptr){
-            delete elem;
+            deleteObject(elem);
         }
     }
     argv.clear();
     if(body != nullptr){
-        delete body;
+        deleteObject(body);
         body = nullptr;
     }
 }
@@ -504,7 +517,7 @@ Unary::Unary(){
 
 Unary::~Unary(){
     if(val != nullptr){
-        delete val;
+        deleteObject(val);
         val = nullptr;
     }
 }
@@ -538,7 +551,7 @@ Seq::Seq(){
 Seq::~Seq(){
     for(const auto &elem : stmt){
         if(elem != nullptr){
-            delete elem;
+            deleteObject(elem);
         }
     }
 }
@@ -583,15 +596,15 @@ If::If(){
 
 If::~If(){
     if(condition != nullptr){
-        delete condition;
+        deleteObject(condition);
         condition = nullptr;
     }
     if(body != nullptr){
-        delete body;
+        deleteObject(body);
         body = nullptr;
     }
     if(Else != nullptr){
-        delete Else;
+        deleteObject(Else);
         Else = nullptr;
     }
 }
@@ -641,11 +654,11 @@ Logical::Logical(){
 
 Logical::~Logical(){
     if(left != nullptr){
-        delete left;
+        deleteObject(left);
         left = nullptr;
     }
     if(right != nullptr){
-        delete right;
+        deleteObject(right);
         right = nullptr;
     }
 }
@@ -701,11 +714,11 @@ Assign::Assign(){
 
 Assign::~Assign(){
     if(name != nullptr){
-        delete name;
+        deleteObject(name);
         name = nullptr;
     }
     if(val != nullptr){
-        delete val;
+        deleteObject(val);
         val = nullptr;
     }
 }
@@ -725,7 +738,7 @@ Object* Assign::getVal(){
 
 void Assign::replaceVal(Object* nval){
     if(val != nullptr){
-        delete val;
+        deleteObject(val);
     }
     val = nval;
 }
@@ -753,19 +766,19 @@ For::For(){
 
 For::~For(){
     if(declare != nullptr){
-        delete declare;
+        deleteObject(declare);
         declare = nullptr;
     }
     if(condition != nullptr){
-        delete condition;
+        deleteObject(condition);
         condition = nullptr;
     }
     if(incrementor != nullptr){
-        delete incrementor;
+        deleteObject(incrementor);
         incrementor = nullptr;
     }
     if(body != nullptr){
-        delete body;
+        deleteObject(body);
         body = nullptr;
     }
 }
@@ -829,11 +842,11 @@ While::While(Object* _condition, Seq* _body) : While() {
 
 While::~While(){
     if(condition != nullptr){
-        delete condition;
+        deleteObject(condition);
     }
     
     if(body != nullptr){
-        delete body;
+        deleteObject(body);
     }
 }
 
@@ -889,3 +902,13 @@ string getTypeName(Int32 type){
     
     return translation[type];
 }
+
+void deleteObject(Object* o){
+    UInt32 memoryPoolID = o->getMemoryPoolID();
+    if(memoryPool[memoryPoolID] != nullptr){
+        delete memoryPool[memoryPoolID];
+        memoryPool[memoryPoolID] = nullptr;
+    }
+}
+
+

--- a/src/Foundation.cpp
+++ b/src/Foundation.cpp
@@ -159,12 +159,12 @@ String::String(string _val){
     Type = STRING;
     val = _val;
 }
-String::~String(){}
+String::~String(){LOG("Foundation:~String");}
 string String::getVal(){
     return val;
 }
 void String::print(){
-    cout<<"S(\"" <<val<< "\")";
+    cout<<"String(" <<val<< ")";
 }
 
 Object* String::clone(){
@@ -244,6 +244,14 @@ Object* Binary::getRight(){
     return right;
 }
 
+void Binary::setLeft(Object* val){
+    left = val;
+}
+
+void Binary::setRight(Object* val){
+    right = val;
+}
+
 Int32 Binary::getOperation(){
     return operation;
 }
@@ -313,6 +321,14 @@ Object* Compare::getLeft(){
 
 Object* Compare::getRight(){
     return right;
+}
+
+void Compare::setLeft(Object* val){
+    left = val;
+}
+
+void Compare::setRight(Object* val){
+    right = val;
 }
 
 Int32 Compare::getOperation(){
@@ -397,6 +413,7 @@ Print::Print(Object* _val){
 }
 
 Print::~Print(){
+    LOG("Foundation:~Print");
     if(val != nullptr){
         delete val;
         val = nullptr;
@@ -424,6 +441,7 @@ Function::Function(){
 }
 
 Function::~Function(){
+    LOG("Foundation:~Function");
     for(const auto &elem : argv){
         if(elem != nullptr){
             delete elem;
@@ -650,6 +668,14 @@ Object* Logical::getRight(){
     return right;
 }
 
+void Logical::setLeft(Object* val){
+    left = val;
+}
+
+void Logical::setRight(Object* val){
+    right = val;
+}
+
 void Logical::print(){
     cout << "Logical(";
     cout << operation;
@@ -713,7 +739,7 @@ void Assign::print(){
 }
 
 Object* Assign::clone(){
-    Assign* copy = new Assign(name, val->clone());
+    Assign* copy = new Assign(name->clone(), val->clone());
     return copy;
 }
 
@@ -831,4 +857,35 @@ Object* While::clone(){
     While* copy = new While(condition->clone(),
                             Safe_Cast<Seq*>(body->clone()));
     return copy;
+}
+
+
+string getTypeName(Int32 type){
+    string translation[] = {
+        "OBJECT",
+        "VAR",
+        "NUMBER",
+        "BOOLEAN",
+        "INTEGER",
+        "FLOAT",
+        "DOUBLE",
+        "STRING",
+        "VOID",
+        "LET",
+        "BINARY",
+        "COMPARE",
+        "PRINT",
+        "FUNCTION",
+        "UNARY",
+        "SEQ",
+        "IF",
+        "LOGICAL",
+        "ASSIGN",
+        "FOR",
+        "WHILE",
+        "STACKLOC",
+        "REG",
+    };
+    
+    return translation[type];
 }

--- a/src/Foundation.cpp
+++ b/src/Foundation.cpp
@@ -49,6 +49,10 @@ void Object::print(){
     cout<<"Obj()"<<endl;
 }
 
+Object* Object::clone(){
+    return nullptr;
+}
+
 Number::Number(){
     LOG("Foundation:Number");
     Type = NUMBER;
@@ -56,6 +60,10 @@ Number::Number(){
 Number::~Number(){LOG("Foundation:~Number");}
 void Number::print(){
     cout<<"N()";
+}
+
+Object* Number::clone(){
+    return nullptr;
 }
 
 Boolean::Boolean(){
@@ -76,6 +84,11 @@ void Boolean::print(){
     cout<<"Bool("<<val<<")";
 }
 
+Object* Boolean::clone(){
+    Boolean* copy = new Boolean(val);
+    return copy;
+}
+
 Integer::Integer(){
     LOG("Foundation:Integer");
     Type = INTEGER;
@@ -94,6 +107,11 @@ void Integer::print(){
     cout<<"Int("<<val<<")";
 }
 
+Object* Integer::clone(){
+    Integer* copy = new Integer(val);
+    return copy;
+}
+
 Float::Float(){
     Type = FLOAT;
 }
@@ -107,6 +125,11 @@ float Float::getVal(){
 }
 void Float::print(){
     cout<<"Float("<<val<<")";
+}
+
+Object* Float::clone(){
+    Float* copy = new Float(val);
+    return copy;
 }
 
 Double::Double(){
@@ -124,6 +147,11 @@ void Double::print(){
     cout<<"Double("<<val<<")";
 }
 
+Object* Double::clone(){
+    Double* copy = new Double(val);
+    return copy;
+}
+
 String::String(){
     Type = STRING;
 }
@@ -137,6 +165,11 @@ string String::getVal(){
 }
 void String::print(){
     cout<<"S(\"" <<val<< "\")";
+}
+
+Object* String::clone(){
+    String* copy = new String(val);
+    return copy;
 }
 
 Let::Let(){
@@ -173,6 +206,11 @@ void Let::print(){
     cout << "Let(\"" << lval <<"\","<<expectedType<<",";
     rval->print();
     cout << ")";
+}
+
+Object* Let::clone(){
+    Let* copy = new Let(lval, expectedType, rval->clone());
+    return copy;
 }
 
 Binary::Binary(){
@@ -238,6 +276,11 @@ void Binary::print(){
     cout << ",";
     right->print();
     cout << ")";
+}
+
+Object* Binary::clone(){
+    Binary* copy = new Binary(operation, left->clone(), right->clone());
+    return copy;
 }
 
 Compare::Compare(){
@@ -309,6 +352,11 @@ void Compare::print(){
     cout << ")";
 }
 
+Object* Compare::clone(){
+    Compare* copy = new Compare(operation, left->clone(), right->clone());
+    return copy;
+}
+
 Var::Var(){
     Type = VAR;
 }
@@ -331,6 +379,11 @@ Int32 Var::getType(){
 
 void Var::print(){
     cout << "Var(\"" << name << "\", " << type << ")";
+}
+
+Object* Var::clone(){
+    Var* copy = new Var(name, type);
+    return copy;
 }
 
 Print::Print(){
@@ -358,6 +411,11 @@ void Print::print(){
     cout << "Print(";
     val->print();
     cout << ")";
+}
+
+Object* Print::clone(){
+    Print* copy = new Print(val->clone());
+    return copy;
 }
 
 Function::Function(){
@@ -404,6 +462,23 @@ void Function::print(){
     cout << ", " + to_string(return_type) + ")";
 }
 
+Object* Function::clone(){
+    Function* copy;
+    
+    vector<Object*> argvCopy;
+    for(const auto& arg : argv){
+        Object* argCopy = arg->clone();
+        argvCopy.push_back(argCopy);
+    }
+    
+    copy = new Function(name,
+                        argvCopy,
+                        Safe_Cast<Seq*>(body->clone()),
+                        return_type);
+    
+    return copy;
+}
+
 Unary::Unary(){
     Type = UNARY;
     val = nullptr;
@@ -430,6 +505,12 @@ void Unary::print(){
     cout << "Unary(";
     val->print();
     cout << ", " << operation << ")";
+}
+
+Object* Unary::clone(){
+    Unary* copy = new Unary(val->clone(),
+                            operation);
+    return copy;
 }
 
 Seq::Seq(){
@@ -460,6 +541,19 @@ void Seq::print(){
         cout << ", ";
     }
     cout << ")";
+}
+
+Object* Seq::clone(){
+    Seq* copy;
+    vector<Object*> stmtCopy;
+    for(const auto& statement : stmt){
+        Object* statementCopy = statement->clone();
+        stmtCopy.push_back(statementCopy);
+    }
+    
+    copy = new Seq(stmtCopy);
+    
+    return copy;
 }
 
 If::If(){
@@ -514,6 +608,13 @@ void If::print(){
     cout << ")";
 }
 
+Object* If::clone(){
+    If* copy = new If(condition->clone(),
+                      Safe_Cast<Seq*>(body->clone()),
+                      Safe_Cast<Seq*>(Else->clone()));
+    return copy;
+}
+
 Logical::Logical(){
     Type = LOGICAL;
     left = nullptr;
@@ -559,6 +660,13 @@ void Logical::print(){
     cout << ")";
 }
 
+Object* Logical::clone(){
+    Logical* copy = new Logical(operation,
+                                left->clone(),
+                                right->clone());
+    return copy;
+}
+
 Assign::Assign(){
     Type = ASSIGN;
     name = nullptr;
@@ -602,6 +710,11 @@ void Assign::print(){
     cout << ", ";
     val->print();
     cout << ")";
+}
+
+Object* Assign::clone(){
+    Assign* copy = new Assign(name, val->clone());
+    return copy;
 }
 
 For::For(){
@@ -666,6 +779,14 @@ void For::print(){
     cout << ")";
 }
 
+Object* For::clone(){
+    For* copy = new For(declare->clone(),
+                        condition->clone(),
+                        incrementor->clone(),
+                        Safe_Cast<Seq*>(body->clone()));
+    return copy;
+}
+
 While::While(){
     Type = WHILE;
     condition = nullptr;
@@ -704,4 +825,10 @@ void While::print(){
     cout << ", ";
     body->print();
     cout << ")";
+}
+
+Object* While::clone(){
+    While* copy = new While(condition->clone(),
+                            Safe_Cast<Seq*>(body->clone()));
+    return copy;
 }

--- a/src/Foundation.hpp
+++ b/src/Foundation.hpp
@@ -105,9 +105,10 @@ protected:
     Int32  Type = OBJECT;
 public:
     Object();
-    ~Object();
+    virtual ~Object();
     Int32  getType();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Number : public Object {
@@ -115,6 +116,7 @@ public:
     Number();
     ~Number();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Boolean : public Object {
@@ -126,6 +128,7 @@ public:
     ~Boolean();
     bool getVal();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Integer : public Number {
@@ -137,6 +140,7 @@ public:
     ~Integer();
     Int32  getVal();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Float : public Number {
@@ -148,6 +152,7 @@ public:
     ~Float();
     float getVal();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Double : public Number {
@@ -159,6 +164,7 @@ public:
     ~Double();
     double getVal();
     virtual void print();
+    virtual Object* clone();
 };
 
 class String : public Object {
@@ -170,6 +176,7 @@ public:
     ~String();
     string getVal();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Let : public Object {
@@ -185,6 +192,7 @@ public:
     Int32  getExpectedType();
     string getName();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Binary : public Object {
@@ -200,6 +208,7 @@ public:
     Object* getRight();
     Int32  getOperation();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Compare : public Object {
@@ -215,6 +224,7 @@ public:
     Object* getRight();
     Int32  getOperation();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Var : public Object {
@@ -228,6 +238,7 @@ public:
     string getName();
     Int32  getType();
     virtual void print();
+    virtual Object* clone();
 };
 
 
@@ -240,6 +251,7 @@ public:
     ~Print();
     Object* getVal();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Seq : public Object {
@@ -251,6 +263,7 @@ public:
     Seq(vector<Object*>);
     vector<Object*> getStatements();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Function : public Object {
@@ -268,6 +281,7 @@ public:
     Seq* getBody();
     Int32  getReturnType();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Unary : public Object {
@@ -281,6 +295,7 @@ public:
     Object* getVal();
     Int32  getOperation();
     virtual void print();
+    virtual Object* clone();
 };
 
 class If : public Object {
@@ -296,6 +311,7 @@ public:
     Seq* getBody();
     Seq* getElse();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Logical : public Object {
@@ -311,6 +327,7 @@ public:
     Object* getLeft();
     Object* getRight();
     virtual void print();
+    virtual Object* clone();
 };
 
 class Assign : public Object {
@@ -325,6 +342,7 @@ public:
     Object* getVal();
     void replaceVal(Object*);
     virtual void print();
+    virtual Object* clone();
 };
 
 class For : public Object {
@@ -342,6 +360,7 @@ public:
     Object* getIncl();
     Seq* getBody();
     virtual void print();
+    virtual Object* clone();
 };
 
 class While : public Object {
@@ -355,6 +374,7 @@ public:
     Object* getCondition();
     Seq* getBody();
     virtual void print();
+    virtual Object* clone();
 };
 
 template <typename T>

--- a/src/Foundation.hpp
+++ b/src/Foundation.hpp
@@ -12,7 +12,22 @@
 #include <sstream>
 using namespace std;
 
+/*
+ Global types for constant width for cross-platform compilation
+ */
+typedef int8_t      Int8;
+typedef int16_t     Int16;
+typedef int32_t     Int32;
+typedef int64_t     Int64;
+typedef uint8_t     UInt8;
+typedef uint16_t    UInt16;
+typedef uint32_t    UInt32;
+typedef uint32_t    UInt;
+typedef uint64_t    UInt64;
+typedef char        Char;
+
 extern vector<string> Trace;
+
 #define LOG(str) Trace.push_back(str)
 #define Printf(str) cout << str << endl
 #define tuple(T,V) make_tuple(T, V)
@@ -24,21 +39,6 @@ extern vector<string> Trace;
 #define RED     "\e[1;31m"
 #define YELLOW  "\e[1;33m"
 #define WHITE   "\e[0m"
-#define CYAN    "\x1B3[36m"
-
-/*
-    Global types for constant width for cross-platform compilation
-*/
-typedef int8_t      Int8;
-typedef int16_t     Int16;
-typedef int32_t     Int32;
-typedef int64_t     Int64;
-typedef uint8_t     UInt8;
-typedef uint16_t    UInt16;
-typedef uint32_t    UInt32;
-typedef uint32_t    UInt;
-typedef uint64_t    UInt64;
-typedef char        Char;
 
 enum Expr {
     OBJECT,
@@ -104,13 +104,17 @@ bool isPrimative(Int32 Type);
 class Object {
 protected:
     Int32  Type = OBJECT;
+    UInt32 poolID;
 public:
     Object();
     virtual ~Object();
     Int32  getType();
+    UInt32 getMemoryPoolID();
     virtual void print();
     virtual Object* clone();
 };
+
+extern map<Int32, Object*> memoryPool;
 
 class Number : public Object {
 public:
@@ -390,4 +394,5 @@ T Safe_Cast(Object* obj) {
 }
 
 string getTypeName(Int32 type);
+void deleteObject(Object* ptr);
 #endif

--- a/src/Foundation.hpp
+++ b/src/Foundation.hpp
@@ -24,6 +24,7 @@ extern vector<string> Trace;
 #define RED     "\e[1;31m"
 #define YELLOW  "\e[1;33m"
 #define WHITE   "\e[0m"
+#define CYAN    "\x1B3[36m"
 
 /*
     Global types for constant width for cross-platform compilation
@@ -206,6 +207,8 @@ public:
     ~Binary();
     Object* getLeft();
     Object* getRight();
+    void setLeft(Object*);
+    void setRight(Object*);
     Int32  getOperation();
     virtual void print();
     virtual Object* clone();
@@ -222,6 +225,8 @@ public:
     ~Compare();
     Object* getLeft();
     Object* getRight();
+    void setLeft(Object*);
+    void setRight(Object*);
     Int32  getOperation();
     virtual void print();
     virtual Object* clone();
@@ -326,6 +331,8 @@ public:
     Int32  getOperation();
     Object* getLeft();
     Object* getRight();
+    void setLeft(Object*);
+    void setRight(Object*);
     virtual void print();
     virtual Object* clone();
 };
@@ -382,4 +389,5 @@ T Safe_Cast(Object* obj) {
     return (T)obj;
 }
 
+string getTypeName(Int32 type);
 #endif

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -71,10 +71,12 @@ vector<Object*> Parser::getAST(){
 
 void Parser::parse(){
     LOG("Parser:parse");
-    for(const auto& line : lexems){
+    for(const auto& _line : lexems){
         lineIndex = 0;
-        curr = line[lineIndex];
+        curr = _line[lineIndex];
+        line = _line;
         Object* tree = generic_parse();
+        tree->print();
         abstract_syntax_tree.push_back(tree);
     }
     LOG("Parser:-parse");

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -18,12 +18,15 @@ Parser::Parser(){
 
 Parser::~Parser(){
     LOG("Parser:~Parser");
-    for(const auto& node : abstract_syntax_tree){
+    LOG("Parser:    deleting ast");
+    for(auto& node : abstract_syntax_tree){
         if(node != nullptr){
             delete node;
+            node = nullptr;
         }
     }
-    
+
+    LOG("Parser:    deleting varBindings");
     while(varBindings.size() != 0){
         map<string, Object*> bind = varBindings.top();
         for(const auto& mapping : bind){
@@ -33,6 +36,7 @@ Parser::~Parser(){
         }
         varBindings.pop();
     }
+    LOG("Parser:-~Parser");
 }
 
 Parser::Parser(vector<vector<string>> _lexems) : Parser() {
@@ -279,8 +283,8 @@ Object* Parser::logical_or(){
      Preform static analysis on the result to see if
      optimizations can be applied
      */
-    return analyzer.ConstantFold(volatileVars != 0 ? nullptr : &varBindings,
-                                 result);
+    return result;//analyzer.ConstantFold(volatileVars != 0 ? nullptr : &varBindings,
+                                 //result);
 }
 
 Object* Parser::logical_and(){
@@ -529,5 +533,5 @@ int Parser::getTypeForVar(string name){
 
 void Parser::bindVar(string name, Object* obj){
     map<string, Object*>* last = &(varBindings.top());
-    (*last)[name] = obj;
+    (*last)[name] = obj->clone();
 }

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -76,7 +76,6 @@ void Parser::parse(){
         curr = _line[lineIndex];
         line = _line;
         Object* tree = generic_parse();
-        tree->print();
         abstract_syntax_tree.push_back(tree);
     }
     LOG("Parser:-parse");

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -21,7 +21,7 @@ Parser::~Parser(){
     LOG("Parser:    deleting ast");
     for(auto& node : abstract_syntax_tree){
         if(node != nullptr){
-            delete node;
+            deleteObject(node);
             node = nullptr;
         }
     }
@@ -457,11 +457,11 @@ Object* Parser::is_numeric(string val){
         double d = stod(val);
         num = new Integer(i);
         if(f != i || ((val.find(".") != std::string::npos))){
-            delete num;
+            deleteObject(num);
             num = new class Float(f);
         }
         if(val.length() - val.rfind(".") > 6){
-            delete num;
+            deleteObject(num);
             num = new class Double(d);
         }
         return num;
@@ -517,7 +517,7 @@ map<string, Int32> Parser::popTypeEnv(){
 void Parser::popVarBindingEnv(){
     map<string, Object*>* last = &(varBindings.top());
     for(const auto& binding : (*last)){
-        delete binding.second;
+        deleteObject(binding.second);
     }
     varBindings.pop();
 }

--- a/src/Parser.hpp
+++ b/src/Parser.hpp
@@ -39,6 +39,7 @@ public:
     Object* for_parse();
     Object* while_parse();
     Object* function_parse();
+    Object* static_analysis();
     Object* logical_or();
     Object* logical_and();
     Object* logical_parse();

--- a/src/Static.cpp
+++ b/src/Static.cpp
@@ -14,7 +14,7 @@ Object* Static::Fold(Object* ast){
         string name = v->getName();
         if(isVar(name)){
             Object* obj = varBindings->top()[name];
-            return obj;
+            return obj->clone();
         }
         return ast;
     }
@@ -46,6 +46,19 @@ Object* Static::Fold(Object* ast){
         Binary* b = Safe_Cast<Binary*>(ast);
         Object* l = Fold(b->getLeft());
         Object* r = Fold(b->getRight());
+        
+        /* We must check if the l and r pointer are the same as the original.
+         If they are different, then someone lower in the tree already
+         deleted that portion of the tree, so we must set the correct child to
+         NULL so as to not cause a double free.
+         */
+        if(b->getLeft() != l){
+            b->setLeft(nullptr);
+        }
+        if(b->getRight() != r){
+            b->setRight(nullptr);
+        }
+        
         if(isPrimative(l->getType()) && isPrimative(r->getType()) &&
            (l->getType() == r->getType())){
             if(b->getOperation() == ADD){
@@ -156,6 +169,19 @@ Object* Static::Fold(Object* ast){
         Compare* c = Safe_Cast<Compare*>(ast);
         Object*  l = Fold(c->getLeft());
         Object*  r = Fold(c->getRight());
+        
+        /* We must check if the l and r pointer are the same as the original.
+           If they are different, then someone lower in the tree already
+           deleted that portion of the tree, so we must set the correct child to
+           NULL so as to not cause a double free.
+         */
+        if(c->getLeft() != l){
+            c->setLeft(nullptr);
+        }
+        if(c->getRight() != r){
+            c->setRight(nullptr);
+        }
+        
         if(isPrimative(l->getType()) &&
            isPrimative(r->getType()) &&
            (l->getType() == r->getType()))
@@ -209,6 +235,19 @@ Object* Static::Fold(Object* ast){
         Logical* o = Safe_Cast<Logical*>(ast);
         Object*  l = Fold(o->getLeft());
         Object*  r = Fold(o->getRight());
+        
+        /* We must check if the l and r pointer are the same as the original.
+         If they are different, then someone lower in the tree already
+         deleted that portion of the tree, so we must set the correct child to
+         NULL so as to not cause a double free.
+         */
+        if(o->getLeft() != l){
+            o->setLeft(nullptr);
+        }
+        if(o->getRight() != r){
+            o->setRight(nullptr);
+        }
+        
         if(isPrimative(l->getType()) &&
            isPrimative(r->getType()) &&
            (l->getType() == r->getType()))
@@ -255,4 +294,24 @@ bool Static::isVar(string name){
         return true;
     }
     return false;
+}
+
+void Static::printBindings(){
+    LOG("Static:printBindings");
+    if(varBindings == nullptr){
+        cout << "{\n}" << endl;
+    }else{
+        map<string, Object*>* s = &(varBindings->top());
+        cout << "{" << endl;
+        for(const auto& value : *s){
+            if (value.second != nullptr){
+                cout << "    " << value.first << ", ";
+                value.second->print();
+                cout << ": " << value.second;
+                cout << endl;
+            }
+        }
+        cout << "}" << endl;
+    }
+    LOG("Static:-printBindings");
 }

--- a/src/Static.cpp
+++ b/src/Static.cpp
@@ -25,19 +25,19 @@ Object* Static::Fold(Object* ast){
             if(o->getType() == INTEGER){
                 Int32 neg = -(Safe_Cast<Integer*>(o)->getVal());
                 Integer* result = new Integer(neg);
-                delete ast;
+                deleteObject(ast);
                 return result;
             }
             else if(o->getType() == FLOAT){
                 float neg = -(Safe_Cast<class Float*>(o)->getVal());
                 class Float* result = new class Float(neg);
-                delete ast;
+                deleteObject(ast);
                 return result;
             }
             else if(o->getType() == Double){
                 double neg = -(Safe_Cast<class Double*>(o)->getVal());
                 class Double* result = new class Double(neg);
-                delete ast;
+                deleteObject(ast);
                 return result;
             }
         }
@@ -66,21 +66,21 @@ Object* Static::Fold(Object* ast){
                     Int32 sum = Safe_Cast<Integer*>(l)->getVal() +
                                 Safe_Cast<Integer*>(r)->getVal();
                     Integer* foldResult = new Integer(sum);
-                    delete ast;
+                    deleteObject(ast);
                     return foldResult;
                 }
                 else if(l->getType() == FLOAT){
                     float sum = Safe_Cast<class Float*>(l)->getVal() +
                                 Safe_Cast<class Float*>(r)->getVal();
                     class Float* foldResult = new class Float(sum);
-                    delete ast;
+                    deleteObject(ast);
                     return foldResult;
                 }
                 else if(l->getType() == DOUBLE){
                     double sum = Safe_Cast<class Double*>(l)->getVal() +
                     Safe_Cast<class Double*>(r)->getVal();
                     class Double* foldResult = new class Double(sum);
-                    delete ast;
+                    deleteObject(ast);
                     return foldResult;
                 }
             }
@@ -89,21 +89,21 @@ Object* Static::Fold(Object* ast){
                     Int32 sum = Safe_Cast<Integer*>(l)->getVal() -
                     Safe_Cast<Integer*>(r)->getVal();
                     Integer* foldResult = new Integer(sum);
-                    delete ast;
+                    deleteObject(ast);
                     return foldResult;
                 }
                 else if(l->getType() == FLOAT){
                     float sum = Safe_Cast<class Float*>(l)->getVal() -
                     Safe_Cast<class Float*>(r)->getVal();
                     class Float* foldResult = new class Float(sum);
-                    delete ast;
+                    deleteObject(ast);
                     return foldResult;
                 }
                 else if(l->getType() == DOUBLE){
                     double sum = Safe_Cast<class Double*>(l)->getVal() -
                     Safe_Cast<class Double*>(r)->getVal();
                     class Double* foldResult = new class Double(sum);
-                    delete ast;
+                    deleteObject(ast);
                     return foldResult;
                 }
             }
@@ -112,21 +112,21 @@ Object* Static::Fold(Object* ast){
                     Int32 sum = Safe_Cast<Integer*>(l)->getVal() *
                     Safe_Cast<Integer*>(r)->getVal();
                     Integer* foldResult = new Integer(sum);
-                    delete ast;
+                    deleteObject(ast);
                     return foldResult;
                 }
                 else if(l->getType() == FLOAT){
                     float sum = Safe_Cast<class Float*>(l)->getVal() *
                     Safe_Cast<class Float*>(r)->getVal();
                     class Float* foldResult = new class Float(sum);
-                    delete ast;
+                    deleteObject(ast);
                     return foldResult;
                 }
                 else if(l->getType() == DOUBLE){
                     double sum = Safe_Cast<class Double*>(l)->getVal() *
                     Safe_Cast<class Double*>(r)->getVal();
                     class Double* foldResult = new class Double(sum);
-                    delete ast;
+                    deleteObject(ast);
                     return foldResult;
                 }
             }
@@ -135,21 +135,21 @@ Object* Static::Fold(Object* ast){
                     Int32 sum = Safe_Cast<Integer*>(l)->getVal() /
                     Safe_Cast<Integer*>(r)->getVal();
                     Integer* foldResult = new Integer(sum);
-                    delete ast;
+                    deleteObject(ast);
                     return foldResult;
                 }
                 else if(l->getType() == FLOAT){
                     float sum = Safe_Cast<class Float*>(l)->getVal() /
                     Safe_Cast<class Float*>(r)->getVal();
                     class Float* foldResult = new class Float(sum);
-                    delete ast;
+                    deleteObject(ast);
                     return foldResult;
                 }
                 else if(l->getType() == DOUBLE){
                     double sum = Safe_Cast<class Double*>(l)->getVal() /
                     Safe_Cast<class Double*>(r)->getVal();
                     class Double* foldResult = new class Double(sum);
-                    delete ast;
+                    deleteObject(ast);
                     return foldResult;
                 }
             }
@@ -158,7 +158,7 @@ Object* Static::Fold(Object* ast){
                     Int32 sum = Safe_Cast<Integer*>(l)->getVal() %
                     Safe_Cast<Integer*>(r)->getVal();
                     Integer* foldResult = new Integer(sum);
-                    delete ast;
+                    deleteObject(ast);
                     return foldResult;
                 }
             }
@@ -190,42 +190,42 @@ Object* Static::Fold(Object* ast){
                 Int32 lt = Safe_Cast<Integer*>(l)->getVal() <
                            Safe_Cast<Integer*>(r)->getVal();
                 Boolean* result = new Boolean(lt);
-                delete ast;
+                deleteObject(ast);
                 return result;
             }
             else if(c->getOperation() == LTE){
                 Int32 lte = Safe_Cast<Integer*>(l)->getVal() <=
                 Safe_Cast<Integer*>(r)->getVal();
                 Boolean* result = new Boolean(lte);
-                delete ast;
+                deleteObject(ast);
                 return result;
             }
             else if(c->getOperation() == EQU){
                 Int32 eq = Safe_Cast<Integer*>(l)->getVal() ==
                 Safe_Cast<Integer*>(r)->getVal();
                 Boolean* result = new Boolean(eq);
-                delete ast;
+                deleteObject(ast);
                 return result;
             }
             else if(c->getOperation() == GTE){
                 Int32 gte = Safe_Cast<Integer*>(l)->getVal() >=
                 Safe_Cast<Integer*>(r)->getVal();
                 Boolean* result = new Boolean(gte);
-                delete ast;
+                deleteObject(ast);
                 return result;
             }
             else if(c->getOperation() == GT){
                 Int32 gt = Safe_Cast<Integer*>(l)->getVal() >
                 Safe_Cast<Integer*>(r)->getVal();
                 Boolean* result = new Boolean(gt);
-                delete ast;
+                deleteObject(ast);
                 return result;
             }
             else if(c->getOperation() == NEQ){
                 Int32 neq = Safe_Cast<Integer*>(l)->getVal() !=
                 Safe_Cast<Integer*>(r)->getVal();
                 Boolean* result = new Boolean(neq);
-                delete ast;
+                deleteObject(ast);
                 return result;
             }
         }
@@ -256,14 +256,14 @@ Object* Static::Fold(Object* ast){
                 Int32 res = Safe_Cast<Boolean*>(l)->getVal() ||
                           Safe_Cast<Boolean*>(r)->getVal();
                 Boolean* result = new Boolean(res);
-                delete ast;
+                deleteObject(ast);
                 return result;
             }
             else if(o->getOperation() == AND){
                 Int32 res = Safe_Cast<Boolean*>(l)->getVal() &&
                           Safe_Cast<Boolean*>(r)->getVal();
                 Boolean* result = new Boolean(res);
-                delete ast;
+                deleteObject(ast);
                 return result;
             }
         }

--- a/src/Static.hpp
+++ b/src/Static.hpp
@@ -15,7 +15,7 @@
 
 class Static {
 private:
-    stack<map<string, Object*>>* varBindings;
+    stack<map<string, Object*>>* varBindings = nullptr;
     Static() {};
     bool isVar(string name);
 public:
@@ -27,6 +27,7 @@ public:
     Object* ConstantFold(stack<map<string, Object*>>* varBindings,
                         Object* ast);
     Object* Fold(Object* ast);
+    void printBindings();
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,16 +29,22 @@ Int32 main(Int32 argc, Char** argv){
             RaisePineException("Expected Pine file.");
         }
         
+        /* Lexer */
         pineSourceFile = argv[1];
         lexer.lex(pineSourceFile);
-
+        
+        /* Parser */
         Parser p = Parser(Lexer::lexem);
         p.parse();
         
-        /* Note: AST will be freed once p leaves the scope */
         vector<Object*> ast = p.getAST();
         
-        Compiler c     = Compiler(ast);
+        /* Compiler */
+        vector<Object*> astCopy;
+        for(auto& tree : ast){
+            astCopy.push_back(tree->clone());
+        }
+        Compiler c = Compiler(astCopy);
         c.generateBinary();
         
         /* Dump log if debug flag is given */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,18 +35,12 @@ Int32 main(Int32 argc, Char** argv){
         Parser p = Parser(Lexer::lexem);
         p.parse();
         
-        /* ast must be freed by whoever last holds it */
+        /* Note: AST will be freed once p leaves the scope */
         vector<Object*> ast = p.getAST();
         
         Compiler c     = Compiler(ast);
         c.generateBinary();
         
-        /* Free ast */
-        for(auto& tree : ast){
-            delete tree;
-            tree = nullptr;
-        }
-            
         /* Dump log if debug flag is given */
         if(argc >= 3 && string(argv[argc-1]) == "-d"){
             RaisePineWarning("Breaking on runtime for debug mode.");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,11 +35,18 @@ Int32 main(Int32 argc, Char** argv){
         Parser p = Parser(Lexer::lexem);
         p.parse();
         
+        /* ast must be freed by whoever last holds it */
         vector<Object*> ast = p.getAST();
         
         Compiler c     = Compiler(ast);
         c.generateBinary();
-                
+        
+        /* Free ast */
+        for(auto& tree : ast){
+            delete tree;
+            tree = nullptr;
+        }
+            
         /* Dump log if debug flag is given */
         if(argc >= 3 && string(argv[argc-1]) == "-d"){
             RaisePineWarning("Breaking on runtime for debug mode.");


### PR DESCRIPTION
- Allocations of `Object*` will be mapped in a memory pool. When objects are freed, it will go through the pool before the `delete` event to prevent double-free assertions. 
- Introduction of `clone` method to detangle nodes that belong to multiple trees. 